### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=I2C communication from an ATTINY85 slave (this library) to an ESP8266 
 category=Communication
 url=http://iot123.com.au
 architectures=*
-includes=
+includes=AssimilateBusSlave.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which #include directives should be added to the sketch via Sketch > Include Library > AssimilateBusSlave. Leaving this field empty causes that action to add the following line to the sketch:
```
#include <>
```
Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format